### PR TITLE
Geometry Dash Super World incompatibility fix

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 	},
 	"id": "alphalaneous.safe_zones_for_ios",
 	"name": "Safe Zones for iOS",
-	"version": "v1.0.9",
+	"version": "v1.0.10",
 	"developer": "Alphalaneous",
 	"description": "Moves buttons away from screen edges",
 	"dependencies": {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,8 @@ std::vector<std::string> g_exclusionsClass = {
 	"AdminSendNoticePopup",
 	"AdminPopup",
 	"AdminPunishUserPopup",
-	"AdminLoginPopup"
+	"AdminLoginPopup",
+        "SuperWorldSelectLayer"
 };
 
 void manualOffset(CCNode* node, float offset) {


### PR DESCRIPTION
Excludes the layer to fix this monstrosity
![image](https://github.com/user-attachments/assets/ce6d0df4-0e2d-48ad-ab70-47b675027773)
